### PR TITLE
Fix "different" Validator to accept input given in dot notation.

### DIFF
--- a/src/Illuminate/Validation/Validator.php
+++ b/src/Illuminate/Validation/Validator.php
@@ -725,9 +725,9 @@ class Validator implements MessageProviderInterface {
 	{
 		$this->requireParameterCount(1, $parameters, 'different');
 
-		$other = $parameters[0];
+		$other = array_get($this->data, $parameters[0]);
 
-		return isset($this->data[$other]) && $value != $this->data[$other];
+		return (isset($other) && $value != $other);
 	}
 
 	/**


### PR DESCRIPTION
Right now, this validator always fails input that's given as dot notation. I have altered it to have the same form as the the (correctly-behaving) "same" validator. It's actually only one character different now, doing inequality rather than equality.

Note, this also affects 4.2 and needs to be back-ported.